### PR TITLE
Make Husky a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 		"detect-indent": "^5.0.0",
 		"he": "^1.1.1",
 		"highlight.js": "^9.12.0",
-		"husky": "^0.14.3",
 		"min-indent": "^1.0.0",
 		"strip-ansi": "^4.0.0",
 		"strip-indent": "^2.0.0",
@@ -36,6 +35,7 @@
 	"devDependencies": {
 		"ava": "^0.25.0",
 		"coveralls": "^3.0.0",
+		"husky": "^0.14.3",
 		"nyc": "^11.6.0",
 		"xo": "^0.20.3"
 	},


### PR DESCRIPTION
When Husky is installed, it takes control of the Git hooks in whatever repository the install is happening in the `node_modules` of. So right now, if any project depends on `@truffle/contract@4.2.9`, it gets its git hooks modified by Husky, because Husky is eventually a transitive non-dev dependency via this project.

This is unacceptable and highly suspicious behavior from a package way down in the dependency tree.

This commit makes Husky a dev dependency, so it should only act on the Git repo of this project that actually wants it.